### PR TITLE
security: validate origin and status before caching in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,13 @@
 const CACHE = 'piscine-SW_VERSION_PLACEHOLDER';
 const STATIC = ['./', './index.html', './manifest.json', './icon.svg'];
 
+// Origins whose responses are safe to serve/cache from this scope.
+// Keep in sync with the connect-src directive in index.html's CSP.
+const ALLOWED_ORIGINS = new Set([
+  self.location.origin,
+  'https://api.open-meteo.com',
+]);
+
 self.addEventListener('install', e => {
   e.waitUntil(
     caches.open(CACHE)
@@ -30,12 +37,28 @@ self.addEventListener('fetch', e => {
   e.respondWith(isData ? networkFirst(e.request) : cacheFirst(e.request));
 });
 
+// Only cache responses that are same-origin (or explicitly allow-listed),
+// not redirected, not opaque, and returned a 2xx status. This defends
+// against cross-origin cache poisoning on hostile networks.
+function isSafeToCache(res) {
+  if (!res || !res.ok) return false;
+  if (res.redirected) return false;
+  if (res.type === 'opaque' || res.type === 'opaqueredirect') return false;
+  try {
+    const origin = new URL(res.url).origin;
+    if (!ALLOWED_ORIGINS.has(origin)) return false;
+  } catch (_) {
+    return false;
+  }
+  return true;
+}
+
 async function cacheFirst(req) {
   const cached = await caches.match(req);
   if (cached) return cached;
   try {
     const res = await fetch(req);
-    if (res.ok) (await caches.open(CACHE)).put(req, res.clone());
+    if (isSafeToCache(res)) (await caches.open(CACHE)).put(req, res.clone());
     return res;
   } catch (_) {
     return new Response('Offline', { status: 503 });
@@ -46,7 +69,7 @@ async function networkFirst(req) {
   const cache = await caches.open(CACHE);
   try {
     const res = await fetch(req);
-    if (res.ok) cache.put(req, res.clone());
+    if (isSafeToCache(res)) cache.put(req, res.clone());
     return res;
   } catch (_) {
     const cached = await cache.match(req);


### PR DESCRIPTION
## Summary
- Addresses open Issue #14 ("Service worker does not validate origin on external fetches").
- Adds an explicit allowlist (`self.location.origin`, `https://api.open-meteo.com`) and refuses to put any response into the cache whose final URL is on a non-allowed origin.
- Skips caching on `res.redirected`, `res.type === 'opaque'` / `'opaqueredirect'`, and non-2xx responses. This defends against SW cache poisoning on hostile networks (captive portal / MITM) where a redirect or opaque cross-origin response could otherwise land in the long-lived `piscine-*` cache and persist offline.

## Why this is safe
- The pass-through `fetch(e.request)` path for cross-origin requests is unchanged: Open-Meteo responses are still returned to the caller live.
- The only behavioural change is the cache `put` is now gated by `isSafeToCache(res)`. On network failure the same offline response is returned as before.

## Test plan
- [ ] `/` loads with the new SW installed and the "Chargement" boot screen is replaced by data as before.
- [ ] Airplane mode: static assets still serve from cache (the initial install-time `cache.addAll` still runs on install).
- [ ] In devtools Application → Service Workers → Update, confirm the new worker activates and the old `piscine-*` caches are purged.
- [ ] Open-Meteo fetch returns live data (no caching expected for cross-origin — unchanged).

## Notes
- `connect-src` in the page CSP still pins Open-Meteo, so the SW allowlist stays in lockstep.
- SW version string `SW_VERSION_PLACEHOLDER` is still replaced by the Actions workflow via `sed` — that step is unchanged.

Tracks finding from the 2026-04-24 security re-review. Full report at `security-review-piscinemonitoring.md` on `claude/blissful-turing-LotRY`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QACgjzNRiGYjif2Mn3WCg)_