### PR TITLE
security: restrict service worker cross-origin fetches to allowlisted hosts

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,15 @@
 const CACHE = 'piscine-SW_VERSION_PLACEHOLDER';
 const STATIC = ['./', './index.html', './manifest.json', './icon.svg'];
 
+// Hosts the app legitimately fetches from. Anything else is refused by the SW
+// so a future XSS or extension cannot turn the SW into an open proxy.
+const ALLOWED_EXTERNAL_HOSTS = new Set([
+  'api.open-meteo.com',
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'unpkg.com',
+]);
+
 self.addEventListener('install', e => {
   e.waitUntil(
     caches.open(CACHE)
@@ -18,12 +27,22 @@ self.addEventListener('activate', e => {
 });
 
 self.addEventListener('fetch', e => {
+  // Only handle GET. Anything else (POST/PUT/etc.) is left to the network so
+  // the SW can never inadvertently cache mutating requests.
+  if (e.request.method !== 'GET') return;
+
   const url = new URL(e.request.url);
-  // External requests (e.g. Open-Meteo API) bypass the cache entirely
+
   if (url.hostname !== self.location.hostname) {
-    e.respondWith(fetch(e.request));
+    // Cross-origin: only proxy hosts the app actually uses.
+    if (ALLOWED_EXTERNAL_HOSTS.has(url.hostname)) {
+      e.respondWith(fetch(e.request));
+    } else {
+      e.respondWith(new Response('Blocked by service worker', { status: 403 }));
+    }
     return;
   }
+
   const isData = url.pathname.endsWith('status.json')
     || url.pathname.endsWith('history.json')
     || url.pathname.endsWith('daily_summary.json');


### PR DESCRIPTION
## Summary
The service worker `fetch` handler currently bypasses the cache for *any* host that
is not the page origin and proxies it through `fetch()` directly. The check is just
`url.hostname !== self.location.hostname`. That means if a future code path (an XSS
sneaking past CSP, a misbehaving browser extension, or a bug that constructs an
attacker-controlled URL) issues a request to `https://attacker.example/...`, the
service worker silently proxies it. The same control would apply equally to
exfiltration-style requests built into a payload.

This PR replaces the open bypass with a small allowlist of hosts the app
legitimately uses (`api.open-meteo.com`, `fonts.googleapis.com`,
`fonts.gstatic.com`, `unpkg.com`). Anything else gets a `403 Blocked by service
worker` response from the SW. It also limits the SW to `GET` so it can never
accidentally cache mutating requests.

## Changes
- `sw.js`: introduce `ALLOWED_EXTERNAL_HOSTS`; refuse non-GET; refuse non-allowlisted cross-origin GETs.

## Test plan
- [ ] Open `piscine.florian-casse.fr`, confirm pool/forecast load (Open-Meteo allowed).
- [ ] In DevTools console run `fetch('https://example.com')` — confirm SW returns 403.
- [ ] Confirm `fonts.googleapis.com` requests still succeed.
- [ ] Confirm `unpkg.com` React/Babel scripts still load on cold cache.

https://claude.ai/code/session_01LgJhkzXY7CK6QQiDiUbc9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgJhkzXY7CK6QQiDiUbc9r)_