### PR TITLE
security: harden CSP with form-action and upgrade-insecure-requests

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -77,6 +77,14 @@ jobs:
         run: |
           sed -i "s/SW_VERSION_PLACEHOLDER/${GITHUB_SHA::7}/g" sw.js
 
+      - name: Harden Content-Security-Policy (additive directives)
+        shell: bash
+        run: |
+          # Append `form-action 'self'` and `upgrade-insecure-requests` to the
+          # CSP meta tag in index.html at deploy time. These are additive and
+          # do not break any current resources.
+          sed -i "s|frame-ancestors 'none'\"|frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests\"|g" index.html
+
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- The CSP meta tag in `index.html` is missing `form-action` and `upgrade-insecure-requests` directives.
- Without `form-action 'self'`, an injected/legacy `<form>` could submit data to an attacker-controlled origin.
- Without `upgrade-insecure-requests`, an http:// resource referenced anywhere in the page (now or later) would be fetched in cleartext.

## Fix
Add a deploy-time `sed` step in `.github/workflows/update-status.yml` (mirroring the existing `SW_VERSION_PLACEHOLDER` injection) that appends `; form-action 'self'; upgrade-insecure-requests` to the CSP meta tag. This is additive and does not break any current resource.

## Test plan
- [ ] Trigger the workflow (any `repository_dispatch`) and verify the deployed `index.html` CSP includes both new directives.
- [ ] Open the live site and confirm no CSP violations appear in the console.
- [ ] Confirm fonts (`fonts.googleapis.com`, `fonts.gstatic.com`), Open-Meteo API, and unpkg scripts still load.

Severity: MEDIUM
Labels: Claude, medium

https://claude.ai/code/session_security_review

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkNP4MnnBv6Vss6kb4fLy4)_