### PR TITLE
security: validate and canonicalize status.json before writing

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -26,7 +26,21 @@ jobs:
         env:
           PAYLOAD: ${{ toJson(github.event.client_payload) }}
         run: |
-          echo "$PAYLOAD" > status.json
+          python3 << 'EOF'
+          import json, os, sys
+          raw = os.environ.get('PAYLOAD', '')
+          try:
+              data = json.loads(raw)
+          except (json.JSONDecodeError, ValueError) as e:
+              print(f"ERROR: client_payload is not valid JSON: {e}", file=sys.stderr)
+              sys.exit(1)
+          if not isinstance(data, dict):
+              print("ERROR: client_payload must be a JSON object", file=sys.stderr)
+              sys.exit(1)
+          with open('status.json', 'w') as f:
+              json.dump(data, f, separators=(',', ':'))
+          print(f"status.json: {len(data)} keys")
+          EOF
 
       - name: Append to history.json
         env:


### PR DESCRIPTION
## Summary
- The workflow currently writes `status.json` via `echo "$PAYLOAD" > status.json`. The payload originates from the `repository_dispatch` sender and is not validated as JSON before being committed and served to clients.
- A malformed payload would corrupt `status.json` and break the dashboard for all users until the next dispatch.
- `echo` may also reinterpret backslashes / `-e`-like sequences in some shells; switching to a Python writer eliminates that class of issue.

## Fix
Replace the `echo` step with a Python heredoc that:
- parses `PAYLOAD` with `json.loads()`,
- rejects non-object payloads (`isinstance(data, dict)`),
- re-serializes via `json.dump(..., separators=(',', ':'))`.

## Test plan
- [ ] Trigger a normal `update_pool_status` dispatch and verify `status.json` is written and the dashboard updates.
- [ ] Send a deliberately invalid payload and verify the workflow step fails fast (does not commit a broken file).
- [ ] Confirm `history.json` and `daily_summary.json` continue to update.

Severity: LOW
Labels: Claude, low

https://claude.ai/code/session_security_review

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkNP4MnnBv6Vss6kb4fLy4)_