### PR TITLE
security(sw): harden service worker cache (only basic, non-redirected responses)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -18,24 +18,38 @@ self.addEventListener('activate', e => {
 });
 
 self.addEventListener('fetch', e => {
+  // Only handle GET — never cache POST/PUT/DELETE
+  if (e.request.method !== 'GET') return;
+
   const url = new URL(e.request.url);
+
+  // Only handle http(s); ignore chrome-extension://, data:, etc.
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return;
+
   // External requests (e.g. Open-Meteo API) bypass the cache entirely
-  if (url.hostname !== self.location.hostname) {
+  if (url.origin !== self.location.origin) {
     e.respondWith(fetch(e.request));
     return;
   }
+
   const isData = url.pathname.endsWith('status.json')
     || url.pathname.endsWith('history.json')
     || url.pathname.endsWith('daily_summary.json');
   e.respondWith(isData ? networkFirst(e.request) : cacheFirst(e.request));
 });
 
+// Only same-origin, non-redirected, 2xx responses may be cached.
+// Opaque / opaqueredirect / cors / error responses are never written.
+function isCacheable(res) {
+  return res && res.ok && res.type === 'basic' && !res.redirected;
+}
+
 async function cacheFirst(req) {
   const cached = await caches.match(req);
   if (cached) return cached;
   try {
     const res = await fetch(req);
-    if (res.ok) (await caches.open(CACHE)).put(req, res.clone());
+    if (isCacheable(res)) (await caches.open(CACHE)).put(req, res.clone());
     return res;
   } catch (_) {
     return new Response('Offline', { status: 503 });
@@ -46,7 +60,7 @@ async function networkFirst(req) {
   const cache = await caches.open(CACHE);
   try {
     const res = await fetch(req);
-    if (res.ok) cache.put(req, res.clone());
+    if (isCacheable(res)) cache.put(req, res.clone());
     return res;
   } catch (_) {
     const cached = await cache.match(req);


### PR DESCRIPTION
## Summary
- Restricts service worker caching to GET requests only.
- Refuses to cache responses unless `res.type === 'basic'`, `res.ok`, and not redirected (defends against cache poisoning via cross-origin redirects or opaque responses).
- Switches the same-origin check from `hostname` to full `origin` so port/scheme mismatches are also bypassed.
- Skips non-http(s) schemes (chrome-extension://, data:) entirely.

## Test plan
- [ ] Load the page and verify status.json / history.json / daily_summary.json still refresh via networkFirst.
- [ ] Toggle offline and verify cached static assets still serve.
- [ ] Verify no cross-origin requests (e.g. open-meteo, fonts) end up in the SW cache.

https://claude.ai/code/session_01HbN9dNd7oGf7gU5KVa6Yvu

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbN9dNd7oGf7gU5KVa6Yvu)_