### PR TITLE
security(ci): stage only public assets for Pages artifact (do not publish whole repo)

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -77,11 +77,21 @@ jobs:
         run: |
           sed -i "s/SW_VERSION_PLACEHOLDER/${GITHUB_SHA::7}/g" sw.js
 
+      # Stage only the files that should be publicly served. This avoids
+      # publishing .github/, scripts/, CLAUDE.md, TODOS.md, README.md, etc.
+      # to GitHub Pages.
+      - name: Stage public assets
+        shell: bash
+        run: |
+          mkdir -p _site
+          cp -v index.html sw.js manifest.json icon.svg CNAME _site/
+          cp -v status.json history.json daily_summary.json _site/
+
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: '_site'
 
       - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
## Summary
- The deploy workflow used `actions/upload-pages-artifact@v3` with `path: '.'`, publishing every file in the repo (`.github/`, `scripts/`, `CLAUDE.md`, `TODOS.md`, `.gitignore`, etc.) to the public Pages origin.
- Adds a `Stage public assets` step that copies only the runtime files (`index.html`, `sw.js`, `manifest.json`, `icon.svg`, `CNAME`, and the three data JSONs) into a `_site/` directory.
- Uploads `_site/` instead of the whole working tree. Future accidentally-committed files (notes, tokens, internal scripts) will not be auto-published.

## Test plan
- [ ] Trigger the workflow with a sample `repository_dispatch` payload.
- [ ] Confirm the deployed Pages site no longer serves `/CLAUDE.md`, `/TODOS.md`, `/scripts/aggregate_daily.py`, `/.github/workflows/update-status.yml`.
- [ ] Confirm `/`, `/sw.js`, `/manifest.json`, `/icon.svg`, `/status.json`, `/history.json`, `/daily_summary.json` still resolve.

https://claude.ai/code/session_01HbN9dNd7oGf7gU5KVa6Yvu

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbN9dNd7oGf7gU5KVa6Yvu)_