### PR TITLE
security: skip cross-origin requests in service worker fetch handler

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -19,11 +19,12 @@ self.addEventListener('activate', e => {
 
 self.addEventListener('fetch', e => {
   const url = new URL(e.request.url);
-  // External requests (e.g. Open-Meteo API) bypass the cache entirely
-  if (url.hostname !== self.location.hostname) {
-    e.respondWith(fetch(e.request));
-    return;
-  }
+  // Only handle same-origin GET requests. Cross-origin traffic (Open-Meteo API,
+  // Google Fonts, unpkg CDN, etc.) is left to the browser so the service worker
+  // is never in the response chain for traffic it does not own.
+  if (url.origin !== self.location.origin) return;
+  if (e.request.method !== 'GET') return;
+
   const isData = url.pathname.endsWith('status.json')
     || url.pathname.endsWith('history.json')
     || url.pathname.endsWith('daily_summary.json');


### PR DESCRIPTION
## Summary
- The service worker fetch handler currently calls `fetch(e.request)` for every cross-origin request (unpkg, Google Fonts, Open-Meteo API), placing the SW in the response chain for traffic it does not control. Returning early without `respondWith` lets the browser handle those requests directly, identical to having no SW for that origin.
- Also restricts handling to `GET` only — POST/PUT/DELETE were caught by the cache-first path and would have been served stale or 503 instead of failing cleanly.

## Why this matters
Per OWASP service worker guidance, a service worker should only respond to requests on its own origin. Wrapping third-party traffic adds an unnecessary attack surface (any future SW logic change can leak or tamper with that traffic) and risks subtle bugs where opaque cross-origin responses are cached incorrectly.

## Test plan
- [ ] Load the site offline — same-origin static assets still served from cache.
- [ ] Verify Open-Meteo fetch still works online (network tab shows direct fetch, no SW interception).
- [ ] DevTools > Application > Service Workers shows no `(from ServiceWorker)` label on `fonts.googleapis.com` / `unpkg.com` / `api.open-meteo.com` requests after the new SW activates.

https://claude.ai/code/session_01KZgHwtwTXanUJSoMEuE4QE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZgHwtwTXanUJSoMEuE4QE)_