### PR TITLE
[MEDIUM] Security review 2026-05-20: workflow + cache hardening

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -8,32 +8,60 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+permissions: {}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Write status.json from HA payload
+      - name: Validate and write status.json from HA payload
         env:
           PAYLOAD: ${{ toJson(github.event.client_payload) }}
         run: |
-          echo "$PAYLOAD" > status.json
+          python3 << 'EOF'
+          import json, os, sys
+          raw = os.environ.get('PAYLOAD', '')
+          try:
+              p = json.loads(raw)
+          except (json.JSONDecodeError, ValueError) as exc:
+              print(f"ERROR: payload not valid JSON: {exc}", file=sys.stderr)
+              sys.exit(1)
+          if not isinstance(p, dict):
+              print("ERROR: payload must be a JSON object", file=sys.stderr)
+              sys.exit(1)
+          allowed = {
+              'updated_at': (str,),
+              'temp_water_c': (int, float, type(None)),
+              'temp_air_c': (int, float, type(None)),
+              'pump_on': (bool, type(None)),
+              'swimmable': (bool, type(None)),
+              'solar_energy_total_kwh': (int, float, type(None)),
+              'sensors_ok': (bool, type(None)),
+              'reason': (str, type(None)),
+          }
+          clean = {}
+          for key, types in allowed.items():
+              if key in p and isinstance(p[key], types):
+                  clean[key] = p[key]
+          with open('status.json', 'w') as fh:
+              json.dump(clean, fh)
+          EOF
 
       - name: Append to history.json
         env:
           PAYLOAD: ${{ toJson(github.event.client_payload) }}
         run: |
           python3 << 'EOF'
-          import json, os
+          import json, os, sys
           f = 'history.json'
           if os.path.exists(f):
               try:
@@ -43,14 +71,28 @@ jobs:
                   history = {"entries": []}
           else:
               history = {"entries": []}
-          p = json.loads(os.environ['PAYLOAD'])
+          try:
+              p = json.loads(os.environ.get('PAYLOAD', ''))
+          except (json.JSONDecodeError, ValueError):
+              print("ERROR: payload not valid JSON; skipping append", file=sys.stderr)
+              sys.exit(1)
+          if not isinstance(p, dict):
+              print("ERROR: payload must be a JSON object; skipping append", file=sys.stderr)
+              sys.exit(1)
+          def num_or_none(v):
+              return v if isinstance(v, (int, float)) and not isinstance(v, bool) else None
+          def bool_or_none(v):
+              return v if isinstance(v, bool) else None
+          ts = p.get("updated_at", "")
+          if not isinstance(ts, str):
+              ts = ""
           history["entries"].append({
-              "ts": p.get("updated_at", ""),
-              "temp_water_c": p.get("temp_water_c"),
-              "temp_air_c": p.get("temp_air_c"),
-              "pump_on": p.get("pump_on"),
-              "swimmable": p.get("swimmable"),
-              "solar_energy_total_kwh": p.get("solar_energy_total_kwh")
+              "ts": ts,
+              "temp_water_c": num_or_none(p.get("temp_water_c")),
+              "temp_air_c": num_or_none(p.get("temp_air_c")),
+              "pump_on": bool_or_none(p.get("pump_on")),
+              "swimmable": bool_or_none(p.get("swimmable")),
+              "solar_energy_total_kwh": num_or_none(p.get("solar_energy_total_kwh"))
           })
           if len(history["entries"]) > 2016:
               history["entries"] = history["entries"][-2016:]

--- a/index.html
+++ b/index.html
@@ -128,18 +128,36 @@ async function tryFetch(path) {
   } catch (_) { return null; }
 }
 
-// Fetch Open-Meteo forecast (7-day + current humidity/wind/uv)
+// Fetch Open-Meteo forecast (7-day + current humidity/wind/uv).
+// Validates coordinate ranges and deduplicates in-flight calls with a 5-minute
+// memoization cache to avoid hammering the API from concurrent loadHouseData()
+// calls or page reloads.
+let _meteoCache = { key: null, ts: 0, promise: null };
+const METEO_TTL_MS = 5 * 60 * 1000;
+function _isValidCoord(lat, lon) {
+  return Number.isFinite(lat) && Number.isFinite(lon)
+    && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
 async function fetchMeteo(lat, lon) {
-  if (!lat || !lon) return null;
-  try {
-    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}`
-      + `&current=relative_humidity_2m,wind_speed_10m,wind_direction_10m,uv_index,apparent_temperature`
-      + `&daily=weather_code,temperature_2m_max,temperature_2m_min`
-      + `&forecast_days=7&timezone=auto`;
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    return await res.json();
-  } catch (_) { return null; }
+  if (!_isValidCoord(lat, lon)) return null;
+  const key = `${lat.toFixed(4)},${lon.toFixed(4)}`;
+  const now = Date.now();
+  if (_meteoCache.key === key && _meteoCache.promise && (now - _meteoCache.ts) < METEO_TTL_MS) {
+    return _meteoCache.promise;
+  }
+  const promise = (async () => {
+    try {
+      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}`
+        + `&current=relative_humidity_2m,wind_speed_10m,wind_direction_10m,uv_index,apparent_temperature`
+        + `&daily=weather_code,temperature_2m_max,temperature_2m_min`
+        + `&forecast_days=7&timezone=auto`;
+      const res = await fetch(url);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (_) { return null; }
+  })();
+  _meteoCache = { key, ts: now, promise };
+  return promise;
 }
 
 // Weather code → icon id (sun | cloud-sun | cloud | rain)
@@ -356,8 +374,10 @@ function buildHouseData(status, daily, history, meteo) {
   const stale = ageMin > STALE_MINUTES;
 
   // Fake-data friendly fallbacks used only when the real field is missing
-  const lat = parseFloat(safeGet('piscine_lat', '43.79')) || 43.79;
-  const lon = parseFloat(safeGet('piscine_lon', '4.83'))  || 4.83;
+  let lat = parseFloat(safeGet('piscine_lat', '43.79'));
+  let lon = parseFloat(safeGet('piscine_lon', '4.83'));
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) lat = 43.79;
+  if (!Number.isFinite(lon) || lon < -180 || lon > 180) lon = 4.83;
 
   return {
     location: { name: safeGet('piscine_location', 'Maison'), lat, lon },
@@ -411,8 +431,10 @@ function buildHouseData(status, daily, history, meteo) {
 }
 
 async function loadHouseData() {
-  const lat = parseFloat(safeGet('piscine_lat', '43.79')) || 43.79;
-  const lon = parseFloat(safeGet('piscine_lon', '4.83'))  || 4.83;
+  let lat = parseFloat(safeGet('piscine_lat', '43.79'));
+  let lon = parseFloat(safeGet('piscine_lon', '4.83'));
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) lat = 43.79;
+  if (!Number.isFinite(lon) || lon < -180 || lon > 180) lon = 4.83;
   const [status, daily, history, meteo] = await Promise.all([
     tryFetch('status.json'),
     tryFetch('daily_summary.json'),

--- a/security-review-piscinemonitoring.md
+++ b/security-review-piscinemonitoring.md
@@ -1,0 +1,81 @@
+# Security Review: PiscineMonitoring
+
+_Last review: 2026-05-20_
+
+## Summary
+- Total findings: 10
+- Critical: 0 | High: 2 | Medium: 6 | Low: 2
+- PRs opened: 1 (consolidated on `claude/youthful-goldberg-TSC54`)
+- Issues opened: 4 (findings that need a maintainer decision or a build artifact that this environment cannot produce)
+
+## Findings
+
+### [HIGH] No Subresource Integrity on unpkg React/ReactDOM/Babel scripts
+- **File:** `index.html` (lines 437-439)
+- **Description:** Three external production scripts (React 18.3.1, ReactDOM 18.3.1, @babel/standalone 7.29.0) are loaded from unpkg.com without `integrity=` attributes. A unpkg / CDN compromise or any cache-poisoning attack on the path lets an attacker substitute malicious code that runs in the page origin with full CSP `'unsafe-inline'`/`'unsafe-eval'` allowances.
+- **Remediation:** Compute sha384 hashes for each pinned version (`curl -s <url> | openssl dgst -sha384 -binary | openssl base64 -A`) and add `integrity="sha384-..." crossorigin="anonymous"` to each `<script>` tag.
+- **PR-ready:** no (this environment cannot reach unpkg.com to generate trustworthy hashes; the hash must come from a host that can fetch the file)
+- **Action taken:** Issue filed.
+
+### [HIGH] CSP allows `'unsafe-inline'` and `'unsafe-eval'`
+- **File:** `index.html` (line 5)
+- **Description:** The CSP `script-src` includes `'unsafe-inline'` and `'unsafe-eval'`. Both are required because the page compiles JSX at runtime via Babel standalone; removing them needs a build step.
+- **Remediation:** Move to a precompile step (e.g. esbuild/vite producing a static `app.js`); drop Babel standalone; tighten CSP to `script-src 'self'` (and the cdnjs/unpkg origins behind SRI). This is a structural change.
+- **PR-ready:** no (architectural refactor)
+- **Action taken:** Issue filed.
+
+### [MEDIUM] Unpinned external library versions (no SRI)
+- **File:** `index.html` (lines 437-439)
+- **Description:** Versions are pinned in URL paths but without cryptographic guarantees; rolls into finding #1.
+- **Remediation:** Addressed by adding SRI hashes (finding #1) or by self-hosting the libraries.
+- **PR-ready:** no
+- **Action taken:** Tracked alongside the SRI Issue.
+
+### [MEDIUM] No coordinate validation / no Open-Meteo request deduplication
+- **File:** `index.html` (lines 132-143, 359-360, 414-415)
+- **Description:** `fetchMeteo()` accepts arbitrary lat/lon read from `localStorage` and is invoked from multiple call sites and every 5 minutes from a setInterval. There is no validation that the values fall within [-90, 90] / [-180, 180], and no in-flight deduplication, so the API can be hammered.
+- **Remediation:** Validate ranges with `Number.isFinite()` and explicit bounds; memoize `fetchMeteo` for 5 minutes keyed on the rounded coordinate pair.
+- **PR-ready:** yes
+- **Action taken:** Fixed in consolidated PR on `claude/youthful-goldberg-TSC54`.
+
+### [MEDIUM] GitHub Actions use mutable version tags rather than pinned SHAs
+- **File:** `.github/workflows/update-status.yml`
+- **Description:** `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4` are referenced by major version. A maintainer of any of those actions can push a new tag with malicious code that this workflow would pick up.
+- **Remediation:** Pin each `uses:` line to a full commit SHA; Dependabot can keep them up to date.
+- **PR-ready:** no (this environment cannot reliably resolve the upstream SHAs for the major actions outside the MCP scope)
+- **Action taken:** Issue filed.
+
+### [MEDIUM] Workflow grants write permissions at the top level
+- **File:** `.github/workflows/update-status.yml` (lines 11-14)
+- **Description:** `contents: write`, `pages: write`, `id-token: write` are declared at the workflow level, applying to every future job/step.
+- **Remediation:** Scope the permissions to the `deploy` job only and declare `permissions: {}` at the top level to deny by default.
+- **PR-ready:** yes
+- **Action taken:** Fixed in consolidated PR on `claude/youthful-goldberg-TSC54`.
+
+### [MEDIUM] Untrusted `client_payload` is written to `status.json` and to `history.json` with no schema validation
+- **File:** `.github/workflows/update-status.yml` (the two heredoc Python steps)
+- **Description:** The first step uses `echo "$PAYLOAD" > status.json` so any caller of the `repository_dispatch` webhook controls the full content of `status.json` (including injecting arbitrary JSON fields). The history-append step accepts whatever types are in the payload. The webhook is gated by a GitHub token but is otherwise treated as trusted input.
+- **Remediation:** Replace the `echo` with a Python heredoc that validates each field against a fixed allowlist and type set, writing only normalised values. Same allowlist for history entries.
+- **PR-ready:** yes
+- **Action taken:** Fixed in consolidated PR on `claude/youthful-goldberg-TSC54`.
+
+### [MEDIUM] Service worker caches data files with no max age
+- **File:** `sw.js` (`networkFirst` function)
+- **Description:** When the network fails, the SW returns the cached body indefinitely. If a user is offline for days and reconnects, the dashboard silently displays stale data. The 503 fallback also returns `{}` rather than the `{entries: []}` shape consumers expect.
+- **Remediation:** Stamp every cached response with a `x-cached-at` header on `put`; on read, treat anything older than 24h as missing. Return `{"entries": []}` for both the no-cache and stale-cache fallback.
+- **PR-ready:** yes
+- **Action taken:** Fixed in consolidated PR on `claude/youthful-goldberg-TSC54`.
+
+### [LOW] localStorage coordinates were not validated before being used
+- **File:** `index.html` (lines 359-360, 414-415)
+- **Description:** A stored-XSS attacker could set `piscine_lat`/`piscine_lon` to arbitrary numeric values and cause unexpected API behaviour.
+- **Remediation:** Range-check inside the getter sites, with safe defaults.
+- **PR-ready:** yes
+- **Action taken:** Fixed in consolidated PR on `claude/youthful-goldberg-TSC54`.
+
+### [LOW] No deduplication or throttle on Open-Meteo calls
+- **File:** `index.html` (`loadHouseData` / `fetchMeteo`)
+- **Description:** Concurrent calls trigger overlapping fetches; the 5-minute setInterval refresh combined with manual reload can multiply the request count.
+- **Remediation:** Memoize Promise for 5 minutes (same fix as MEDIUM #4).
+- **PR-ready:** yes
+- **Action taken:** Fixed in consolidated PR on `claude/youthful-goldberg-TSC54`.

--- a/sw.js
+++ b/sw.js
@@ -42,14 +42,35 @@ async function cacheFirst(req) {
   }
 }
 
+const DATA_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 async function networkFirst(req) {
   const cache = await caches.open(CACHE);
   try {
     const res = await fetch(req);
-    if (res.ok) cache.put(req, res.clone());
+    if (res.ok) {
+      const cloned = res.clone();
+      const headers = new Headers(cloned.headers);
+      headers.set('x-cached-at', String(Date.now()));
+      const body = await cloned.blob();
+      cache.put(req, new Response(body, { status: cloned.status, statusText: cloned.statusText, headers }));
+    }
     return res;
   } catch (_) {
     const cached = await cache.match(req);
-    return cached || new Response('{}', { status: 503, headers: { 'Content-Type': 'application/json' } });
+    if (cached) {
+      const cachedAt = parseInt(cached.headers.get('x-cached-at') || '0', 10);
+      if (cachedAt && Date.now() - cachedAt > DATA_CACHE_MAX_AGE_MS) {
+        return new Response(JSON.stringify({ entries: [] }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return cached;
+    }
+    return new Response(JSON.stringify({ entries: [] }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 }


### PR DESCRIPTION
## Summary

Consolidated fixes for the 2026-05-20 automated security review (see
`security-review-piscinemonitoring.md` on this branch).

| # | Severity | Finding |
|---|---|---|
| 1 | MEDIUM | Workflow: drop top-level write permissions; scope `contents`/`pages`/`id-token` write to the deploy job only. |
| 2 | MEDIUM | Workflow: replace `echo "$PAYLOAD" > status.json` with a Python heredoc that validates each field against a typed allowlist. Same allowlist applied to history append step so a caller of the `repository_dispatch` webhook can no longer inject arbitrary keys/types. |
| 3 | MEDIUM | `sw.js`: stamp `networkFirst` responses with `x-cached-at`; treat cached data older than 24h as missing; return `{"entries": []}` for the 503 fallback (was `{}`, which broke consumers expecting the `entries` array). |
| 4 | LOW | `index.html`: validate `piscine_lat`/`piscine_lon` ranges before use, with safe defaults outside the bounds. |
| 5 | LOW | `index.html`: 5-minute Promise memoization on `fetchMeteo` to deduplicate concurrent calls and protect Open-Meteo from the 5-minute setInterval refresh. |

Two HIGH (no SRI on the three unpkg scripts; CSP `'unsafe-inline'` /
`'unsafe-eval'` only removable via a precompile step) and two MEDIUM
(unpinned GitHub Actions; SRI / self-host for unpinned external libs) findings
are tracked as Issues — they need either trusted SRI hashes or a
build-pipeline decision that's out of scope for this branch.

## Test plan

- [ ] Trigger `update_pool_status` with a payload containing extra fields → those are stripped from `status.json`.
- [ ] Trigger with payload `{"temp_water_c": "hot"}` → field is dropped (not a number).
- [ ] Open page offline > 24h → service worker returns `{entries: []}` 503 instead of stale data.
- [ ] Set `localStorage.piscine_lat = "999"` → falls back to default `43.79`.
- [ ] Two parallel calls to `fetchMeteo(43.79, 4.83)` within 5 minutes → one network request.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jek5DsLDSKHq3WsmRM2BqZ)_