### PR TITLE
fix: align stale-banner threshold with 30-min HA dispatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
 <script>
 /* ========== Data pipeline (vanilla, runs before React) ========== */
 
-const STALE_MINUTES = 15;
+const STALE_MINUTES = 40;
 const SEASON_START_MONTH = 4; // April — week/month totals scope
 const POOL_TARGET = 26;
 const SOLAR_CAPACITY_KW = 6.4;
@@ -429,7 +429,7 @@ window.__dataReady.then(data => {
   if (data && data.stale) {
     const b = document.getElementById('stale-banner');
     b.classList.add('visible');
-    b.textContent = 'Données non actualisées depuis plus de 15 min';
+    b.textContent = `Données non actualisées depuis plus de ${STALE_MINUTES} min`;
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- Raise `STALE_MINUTES` from 15 → 40 to match HA's 30-min dispatch cadence (with 10-min buffer for CI/Pages latency), so the red banner no longer fires as a permanent false positive between normal dispatches.
- Render the banner text from `STALE_MINUTES` to keep copy and threshold in sync.

## Test plan
- [ ] Load dashboard right after a HA dispatch — no banner.
- [ ] In DevTools, force `status.updated_at` to 45+ min ago — banner shows "Données non actualisées depuis plus de 40 min".

🤖 Generated with [Claude Code](https://claude.com/claude-code)